### PR TITLE
fix for date/time hh24 format strings

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -701,7 +701,7 @@ jSuites.calendar.extractDateFromString = function(date, format) {
         s = '00';
     }
 
-    if (test == 1 && date.length == format.length) {
+    if (test == 1 && date.length == v2.length) {
         // Update source
         var data = y + '-' + m + '-' + d + ' ' + h + ':' +  i + ':' + s;
 


### PR DESCRIPTION
Using a date and time format string such as below, no date gets returned from this function.
```format:'DD/MM/YYYY HH24:MI',```

The `v2` variable contains the format string with the `24` stripped out and therefore will match the length of the input `date`. 