### PR TITLE
Fix bug - dropdown data.id mapping to element value and failing

### DIFF
--- a/dist/jsuites.js
+++ b/dist/jsuites.js
@@ -2509,6 +2509,27 @@ jSuites.dropdown = (function(el, options) {
         });
     }
 
+    /* Possible data fields -- mapped to equivalent html elements except group and title, which get treated
+     * progmatically, image => html img tag
+     * ALERT: 'value' field will not map if using DIV type list instead of select type list
+     * data_options = [{
+     *                  'id':      'required',
+     *                  'image':   'optional',
+     *                  'title':   'optional',
+     *                  'name':    'required',
+     *                  'value':   'optional',
+     *                  'group':   'optional'
+     *              },];
+     *
+     * data_example = [
+     *                  {'id': '1', 'image':'', 'title': 'MS', 'name': 'Barbara', 'value': 'BB', 'group': 'GOODIE'},
+     *                  {'id': '2', 'image':'', 'title': 'MR', 'name': 'Gordon', 'value': 'GG', 'group': 'VILAIN'},
+     *              ];
+     * Example use:
+     * onchange: function(el, index, oldValue, newValue, oldLabel, newLabel){
+     *              el.dropdown.items[index].id //or any of the data fields above like .title or .value
+     *           }
+     */
     obj.setData = function(data) {
         if (data) {
             obj.options.data = data;
@@ -2540,8 +2561,9 @@ jSuites.dropdown = (function(el, options) {
                 // Create item
                 items[k] = document.createElement('div');
                 items[k].className = 'jdropdown-item';
-                items[k].value = v.id;
+                items[k].id = v.id;
                 items[k].text = v.name;
+                items[k].value = v.value;
 
                 // Image
                 if (v.image) {
@@ -2638,7 +2660,7 @@ jSuites.dropdown = (function(el, options) {
         }
     }
 
-    obj.setValue = function(value) {
+    obj.setValue = function(id) {
         // Remove values
         var items = el.querySelectorAll('.jdropdown-selected');
         for (var j = 0; j < items.length; j++) {
@@ -2646,18 +2668,18 @@ jSuites.dropdown = (function(el, options) {
         } 
 
         // Set values
-        if (value != null) {
-            if (Array.isArray(value)) {
+        if (id != null) {
+            if (Array.isArray(id)) {
                 for (var i = 0; i < obj.items.length; i++) {
-                    value.forEach(function(val) {
-                        if (obj.items[i].value == val) {
+                    id.forEach(function(id_val) {
+                        if (obj.items[i].id == id_val) {
                             obj.items[i].classList.add('jdropdown-selected');
                         }
                     });
                 }
             } else {
                 for (var i = 0; i < obj.items.length; i++) {
-                    if (obj.items[i].value == value) {
+                    if (obj.items[i].id == id) {
                         obj.items[i].classList.add('jdropdown-selected');
                     }
                 }

--- a/dist/jsuites.js
+++ b/dist/jsuites.js
@@ -5322,15 +5322,51 @@ jSuites.mask = (function() {
     var values = []
     var pieces = [];
 
-    obj.run = function(value, mask, decimal) {
-        if (value && mask) {
-            if (! decimal) {
-                decimal = '.';
-            }
+    obj.run = function( value,             // ex. 1000 or "1000" or "1000.0" or ...
+                        mask,              // ex. "$ #,###.##"
+                        decimal,        // ex. '.'
+                        mask_decimal    // ex. ',' <- French style
+        ) {
+        // Convert value to string so that we can check that it's not a blank field
+        // this also ensures we capture 0 (zero) as a value that we will treat with the mask,
+        // rather than a "false" causing the function to return ''
+        // In the future, we may want to give users the option to select how they want
+        // 0 (zero) value represented
+
+        if (typeof decimal == 'undefined') {  // default parameter value if none specified  for decimal == '.'
+            decimal = '.';
+        }
+
+        if (typeof mask_decimal == 'undefined') {  // default parameter value if none specified for mask_decimal == decimal
+            mask_decimal = decimal;
+        }
+
+        if (value.toString().length && mask.toString().length) {
             if (value == Number(value)) {
-                var number = (''+value).split('.');
-                var value = number[0];
-                var valueDecimal = number[1];
+                var number = (''+value).split(decimal);
+                // Check if the function value argument (number) already has a decimal value
+                if(number.length > 1) {
+                    var value = number[0];
+                    var valueDecimal = '';
+
+                    // Does the mask call for decimal places to be displayed?
+                    if(mask.split(decimal).length > 1) {
+                        // Lets make sure we fill the missing decimals with 0 (zero) values to have the same number of sig-figs as the mask calls for
+                        valueDecimal = number[1];
+                        for (var sf = valueDecimal.toString().length; sf < mask.split(mask_decimal)[1].length; sf++) {
+                            valueDecimal += "0";
+                        }
+                    }
+                } else {
+                    var value = number[0];
+                    var valueDecimal = '';
+                    if(mask.split(decimal).length > 1) {
+                        for (var sf = valueDecimal.toString().length; sf < mask.split(mask_decimal)[1].length; sf++) {
+                            valueDecimal += "0";
+                        }
+                    }
+                }
+                
             } else {
                 value = '' + value;
             }


### PR DESCRIPTION
**SUMMARY:**
data.value now maps to element value instead of to element id, and data.id maps to element id.

**BUG:**
When creating a dropdown on a <div>, there are no ids assigned to the item elements. The value data parameter gets silently dropped, as <div>s don't have a value param, unlike perhaps <select> elements. This means that there is no way to know which element is selected by the user, other than using the data.name field, which is not a good design.

**PROPOSAL:**
I propose to add an id param to the item elements, while also maintaining the value param to maintain backwards compatibility.

Good design patterns suggest that all select-able elements on the client must maintain ids that map to those in the database. Mapping can occur either directly or indirectly, on the client or on the server.