### PR TITLE
Fix selecting valid days when default value is outside valid date range

### DIFF
--- a/dist/jsuites.js
+++ b/dist/jsuites.js
@@ -779,6 +779,11 @@ jSuites.calendar = (function(el, options) {
         } else {
             obj.date[2] = element.innerText;
 
+            if (calendar.querySelector('.jcalendar-selected') != element) {
+                calendar.querySelector('.jcalendar-selected').classList.remove('jcalendar-selected');
+                element.classList.add('jcalendar-selected');
+            }
+            
             if (! obj.options.time) {
                 obj.close();
             } else {


### PR DESCRIPTION
When the current date value of a calendar cell is outside of the `valid` range, a valid value cannot be selected by clicking on a day.

This patch fixes that problem by removing the default selection from the old invalid day cell and applying it to the newly selected cell so that `obj.close()` correctly obtains the new value.