### PR TITLE
Fix double keystroke calendar input

### DIFF
--- a/dist/jsuites.js
+++ b/dist/jsuites.js
@@ -5178,6 +5178,7 @@ jSuites.mask = (function() {
                     obj.process(obj.fromKeyCode(e));
                     // Prevent default
                     e.preventDefault();
+                    e.stopImmediatePropagation();
                 }
                 // Update value to the element
                 e.target.value = values.join('');


### PR DESCRIPTION
Per discussion  paulhodel/jexcel-with-angular#4, input events are bubbling up to Angular (and presumably other frameworks) when JExcel is embedded because keyboard input events are being accepted by JSuites but not being removed for consideration by other event handlers at other levels. 

In Angular `zone.js` also sees the keyboard events causing duplication of keystrokes.

This patch address that by stopping further processing of the events.