### PR TITLE
Fix 00 hours and/or minutes reset to current time

### DIFF
--- a/dist/jsuites.basic.js
+++ b/dist/jsuites.basic.js
@@ -820,12 +820,17 @@ jSuites.calendar = (function(el, options) {
         // Setting current values in case of NULLs
         var date = new Date();
 
+        if(obj.options.value)
+        {
+          obj.date = jSuites.calendar.toArray(obj.options.value);
+        }
+		
         // Current selection
-        var year = obj.date && obj.date[0] ? obj.date[0] : parseInt(date.getFullYear());
-        var month = obj.date && obj.date[1] ? obj.date[1] : parseInt(date.getMonth()) + 1;
-        var day = obj.date && obj.date[2] ? obj.date[2] : parseInt(date.getDate());
-        var hour = obj.date && obj.date[3] || obj.date[3] == 0 ? obj.date[3] : parseInt(date.getHours());
-        var min = obj.date && obj.date[4] || obj.date[4] == 0 ? obj.date[4] : parseInt(date.getMinutes());
+        var year = obj.date && obj.date.length > 0 ? obj.date[0] : parseInt(date.getFullYear());
+        var month = obj.date && obj.date.length > 1 ? obj.date[1] : parseInt(date.getMonth()) + 1;
+        var day = obj.date && obj.date.length > 2 ? obj.date[2] : parseInt(date.getDate());
+        var hour = obj.date && obj.date.length > 3 ? obj.date[3] : parseInt(date.getHours());
+        var min = obj.date && obj.date.length > 4 ? obj.date[4] : parseInt(date.getMinutes());
 
         // Selection container
         obj.date = [year, month, day, hour, min, 0 ];

--- a/dist/jsuites.basic.js
+++ b/dist/jsuites.basic.js
@@ -824,8 +824,8 @@ jSuites.calendar = (function(el, options) {
         var year = obj.date && obj.date[0] ? obj.date[0] : parseInt(date.getFullYear());
         var month = obj.date && obj.date[1] ? obj.date[1] : parseInt(date.getMonth()) + 1;
         var day = obj.date && obj.date[2] ? obj.date[2] : parseInt(date.getDate());
-        var hour = obj.date && obj.date[3] ? obj.date[3] : parseInt(date.getHours());
-        var min = obj.date && obj.date[4] ? obj.date[4] : parseInt(date.getMinutes());
+        var hour = obj.date && obj.date[3] || obj.date[3] == 0 ? obj.date[3] : parseInt(date.getHours());
+        var min = obj.date && obj.date[4] || obj.date[4] == 0 ? obj.date[4] : parseInt(date.getMinutes());
 
         // Selection container
         obj.date = [year, month, day, hour, min, 0 ];

--- a/dist/jsuites.js
+++ b/dist/jsuites.js
@@ -831,12 +831,17 @@ jSuites.calendar = (function(el, options) {
         // Setting current values in case of NULLs
         var date = new Date();
 
+        if(obj.options.value)
+        {
+          obj.date = jSuites.calendar.toArray(obj.options.value);
+        }
+		
         // Current selection
-        var year = obj.date && obj.date[0] ? obj.date[0] : parseInt(date.getFullYear());
-        var month = obj.date && obj.date[1] ? obj.date[1] : parseInt(date.getMonth()) + 1;
-        var day = obj.date && obj.date[2] ? obj.date[2] : parseInt(date.getDate());
-        var hour = obj.date && obj.date[3] || obj.date[3] == 0 ? obj.date[3] : parseInt(date.getHours());
-        var min = obj.date && obj.date[4] || obj.date[4] == 0 ? obj.date[4] : parseInt(date.getMinutes());
+        var year = obj.date && obj.date.length > 0 ? obj.date[0] : parseInt(date.getFullYear());
+        var month = obj.date && obj.date.length > 1 ? obj.date[1] : parseInt(date.getMonth()) + 1;
+        var day = obj.date && obj.date.length > 2 ? obj.date[2] : parseInt(date.getDate());
+        var hour = obj.date && obj.date.length > 3 ? obj.date[3] : parseInt(date.getHours());
+        var min = obj.date && obj.date.length > 4 ? obj.date[4] : parseInt(date.getMinutes());
 
         // Selection container
         obj.date = [year, month, day, hour, min, 0 ];

--- a/dist/jsuites.js
+++ b/dist/jsuites.js
@@ -835,8 +835,8 @@ jSuites.calendar = (function(el, options) {
         var year = obj.date && obj.date[0] ? obj.date[0] : parseInt(date.getFullYear());
         var month = obj.date && obj.date[1] ? obj.date[1] : parseInt(date.getMonth()) + 1;
         var day = obj.date && obj.date[2] ? obj.date[2] : parseInt(date.getDate());
-        var hour = obj.date && obj.date[3] ? obj.date[3] : parseInt(date.getHours());
-        var min = obj.date && obj.date[4] ? obj.date[4] : parseInt(date.getMinutes());
+        var hour = obj.date && obj.date[3] || obj.date[3] == 0 ? obj.date[3] : parseInt(date.getHours());
+        var min = obj.date && obj.date[4] || obj.date[4] == 0 ? obj.date[4] : parseInt(date.getMinutes());
 
         // Selection container
         obj.date = [year, month, day, hour, min, 0 ];

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -487,12 +487,17 @@ jSuites.calendar = (function(el, options) {
         // Setting current values in case of NULLs
         var date = new Date();
 
+        if(obj.options.value)
+        {
+          obj.date = jSuites.calendar.toArray(obj.options.value);
+        }
+		
         // Current selection
-        var year = obj.date && obj.date[0] ? obj.date[0] : parseInt(date.getFullYear());
-        var month = obj.date && obj.date[1] ? obj.date[1] : parseInt(date.getMonth()) + 1;
-        var day = obj.date && obj.date[2] ? obj.date[2] : parseInt(date.getDate());
-        var hour = obj.date && obj.date[3] || obj.date[3] == 0 ? obj.date[3] : parseInt(date.getHours());
-        var min = obj.date && obj.date[4] || obj.date[4] == 0 ? obj.date[4] : parseInt(date.getMinutes());
+        var year = obj.date && obj.date.length > 0 ? obj.date[0] : parseInt(date.getFullYear());
+        var month = obj.date && obj.date.length > 1 ? obj.date[1] : parseInt(date.getMonth()) + 1;
+        var day = obj.date && obj.date.length > 2 ? obj.date[2] : parseInt(date.getDate());
+        var hour = obj.date && obj.date.length > 3 ? obj.date[3] : parseInt(date.getHours());
+        var min = obj.date && obj.date.length > 4 ? obj.date[4] : parseInt(date.getMinutes());
 
         // Selection container
         obj.date = [year, month, day, hour, min, 0 ];

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -491,8 +491,8 @@ jSuites.calendar = (function(el, options) {
         var year = obj.date && obj.date[0] ? obj.date[0] : parseInt(date.getFullYear());
         var month = obj.date && obj.date[1] ? obj.date[1] : parseInt(date.getMonth()) + 1;
         var day = obj.date && obj.date[2] ? obj.date[2] : parseInt(date.getDate());
-        var hour = obj.date && obj.date[3] ? obj.date[3] : parseInt(date.getHours());
-        var min = obj.date && obj.date[4] ? obj.date[4] : parseInt(date.getMinutes());
+        var hour = obj.date && obj.date[3] || obj.date[3] == 0 ? obj.date[3] : parseInt(date.getHours());
+        var min = obj.date && obj.date[4] || obj.date[4] == 0 ? obj.date[4] : parseInt(date.getMinutes());
 
         // Selection container
         obj.date = [year, month, day, hour, min, 0 ];


### PR DESCRIPTION
When using jSuites from jExcel, manually entering date + time resets to current time, when entering `00` as hour or minute.

Note: https://github.com/paulhodel/jsuites/pull/51 was a wrong PR, now fixed, tested the solution.